### PR TITLE
Added additional options for user to select

### DIFF
--- a/options.js
+++ b/options.js
@@ -1,0 +1,25 @@
+import fs from "fs";
+
+function outputOptions(output) {
+  if (output) {
+    if (fs.existsSync(output) && fs.lstatSync(output).isDirectory()) {
+      return output.replace(/\/+$/, "") + "/swagger-api-docs.html";
+    } else {
+      return !output.endsWith(".html") ? output + ".html" : output;
+    }
+  }
+}
+
+function getVersion(spec) {
+  return spec?.info?.version || "unknown";
+}
+
+function versionOption(versionFlag, outputFile, spec) {
+  // Sanitize version string to be filesystem-friendly
+  if (!versionFlag || !spec) return outputFile;
+  const version = getVersion(spec).replace(/[^a-zA-Z0-9.-]/g, "-");
+
+  return outputFile.replace(/\.html$/, `-v${version}.html`);
+}
+
+export { outputOptions, versionOption };

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "chalk": "^5.6.2",
+    "commander": "^14.0.1",
     "node-fetch": "^3.3.2"
   },
   "bin": {


### PR DESCRIPTION
- Added `-o, --output <Path>` and `--versioned `options using commander js. 
  - **output** option:
     Can be used for user to select custom file `.html` name to save or give directory path to save.
   - **versioned** option:
      Can be used to give the file name the version of API taken from `swagger.info.version` 

- These changes can be used to add additional options in the future for scalability.